### PR TITLE
fixes Add class construction on occ when user_ldap is not enabled

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ clone:
 
 steps:
     - name: app-code-check
-      image: nextcloudci/php7.2:php7.2-13
+      image: nextcloudci/php7.4:php7.4-2
       environment:
           APP_NAME: ldap_contacts_backend
           CORE_BRANCH: master
@@ -21,7 +21,7 @@ steps:
         image: nextcloudci/php7.2:php7.2-13
         environment:
             APP_NAME: ldap_contacts_backend
-            CORE_BRANCH: master
+            CORE_BRANCH: stable20
             DB: sqlite
         commands:
             - composer install
@@ -36,7 +36,7 @@ steps:
             - composer install
             - ./vendor/bin/parallel-lint --exclude ./vendor/ .
     -   name: syntax-php7.4
-        image: nextcloudci/php7.4:php7.4-1
+        image: nextcloudci/php7.4:php7.4-2
         environment:
             APP_NAME: ldap_write_support
             CORE_BRANCH: master
@@ -109,5 +109,166 @@ trigger:
     event:
         - pull_request
         - push
+
+type: docker
+
+---
+kind: pipeline
+name: tests-master
+
+clone:
+  depth: 1
+
+steps:
+  - name: php7.3
+    image: nextcloudci/php7.3:php7.3-5
+    environment:
+      APP_NAME: ldap_contacts_backend
+      CORE_BRANCH: master
+      DB: sqlite
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
+      - cd ../server/apps/$APP_NAME
+      - composer install
+      - cd tests/phpunit/
+      - phpunit --configuration phpunit.xml
+  - name: php7.4
+    image: nextcloudci/php7.4:php7.4-1
+    environment:
+      APP_NAME: ldap_contacts_backend
+      CORE_BRANCH: master
+      DB: sqlite
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
+      - cd ../server/apps/$APP_NAME
+      - composer install
+      - cd tests/phpunit/
+      - phpunit --configuration phpunit.xml
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+    - pull_request
+    - push
+
+type: docker
+
+---
+kind: pipeline
+name: tests-stable20
+
+clone:
+  depth: 1
+
+steps:
+  - name: php7.2
+    image: nextcloudci/php7.2:php7.2-13
+    environment:
+      APP_NAME: ldap_contacts_backend
+      CORE_BRANCH: stable20
+      DB: sqlite
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
+      - cd ../server/apps/$APP_NAME
+      - composer install
+      - cd tests/phpunit/
+      - phpunit --configuration phpunit.xml
+  - name: php7.3
+    image: nextcloudci/php7.3:php7.3-5
+    environment:
+      APP_NAME: ldap_contacts_backend
+      CORE_BRANCH: stable20
+      DB: sqlite
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
+      - cd ../server/apps/$APP_NAME
+      - composer install
+      - cd tests/phpunit/
+      - phpunit --configuration phpunit.xml
+  - name: php7.4
+    image: nextcloudci/php7.4:php7.4-2
+    environment:
+      APP_NAME: ldap_contacts_backend
+      CORE_BRANCH: stable20
+      DB: sqlite
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
+      - cd ../server/apps/$APP_NAME
+      - composer install
+      - cd tests/phpunit/
+      - phpunit --configuration phpunit.xml
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+    - pull_request
+    - push
+
+type: docker
+
+---
+kind: pipeline
+name: tests-stable19
+
+clone:
+  depth: 1
+
+steps:
+  - name: php7.2
+    image: nextcloudci/php7.2:php7.2-13
+    environment:
+      APP_NAME: ldap_contacts_backend
+      CORE_BRANCH: stable19
+      DB: sqlite
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
+      - cd ../server/apps/$APP_NAME
+      - composer install
+      - cd tests/phpunit/
+      - phpunit --configuration phpunit.xml
+  - name: php7.3
+    image: nextcloudci/php7.3:php7.3-5
+    environment:
+      APP_NAME: ldap_contacts_backend
+      CORE_BRANCH: stable19
+      DB: sqlite
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
+      - cd ../server/apps/$APP_NAME
+      - composer install
+      - cd tests/phpunit/
+      - phpunit --configuration phpunit.xml
+  - name: php7.4
+    image: nextcloudci/php7.4:php7.4-2
+    environment:
+      APP_NAME: ldap_contacts_backend
+      CORE_BRANCH: stable19
+      DB: sqlite
+    commands:
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
+      - cd ../server/apps/$APP_NAME
+      - composer install
+      - cd tests/phpunit/
+      - phpunit --configuration phpunit.xml
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+    - pull_request
+    - push
 
 type: docker

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,7 +32,7 @@ Given that the configuration is correct, you and your users will be able to sear
     <dependencies>
 		<php min-version="7.2"/>
 		<lib>ldap</lib>
-		<nextcloud min-version="19" max-version="20"/>
+		<nextcloud min-version="19" max-version="21"/>
     </dependencies>
 	<commands>
 		<command>OCA\LDAPContactsBackend\Command\Add</command>

--- a/lib/Command/Add.php
+++ b/lib/Command/Add.php
@@ -25,7 +25,6 @@ declare(strict_types=1);
 namespace OCA\LDAPContactsBackend\Command;
 
 use OC\Core\Command\Base;
-use OCA\LDAPContactsBackend\Model\LDAPBaseConfiguration;
 use OCA\LDAPContactsBackend\Service\Configuration;
 use OCA\LDAPContactsBackend\Service\ConnectionImporter;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -40,10 +39,10 @@ class Add extends Base {
 
 	/** @var Configuration */
 	private $configurationService;
-	/** @var ConnectionImporter */
+	/** @var ConnectionImporter|null */
 	private $connectionImporter;
 
-	public function __construct(Configuration $configurationService, ConnectionImporter $connectionImporter) {
+	public function __construct(Configuration $configurationService, ?ConnectionImporter $connectionImporter = null) {
 		parent::__construct();
 		$this->configurationService = $configurationService;
 		$this->connectionImporter = $connectionImporter;
@@ -282,7 +281,7 @@ class Add extends Base {
 
 	protected function importConnection(InputInterface $input) {
 		static $wasRun = false;
-		if($wasRun) {
+		if($wasRun || !$this->connectionImporter instanceof ConnectionImporter) {
 			// avoid running twice during interact && executed
 			return;
 		}


### PR DESCRIPTION
ConnectionImporter depends on LDAP backend's helper class :see_no_evil: and if it cannot be found and instantiated occ breaks with

```
 php occ status
An unhandled exception has been thrown:
ArgumentCountError: Too few arguments to function OCA\LDAPContactsBackend\Command\Add::__construct(), 0 passed in /srv/http/nextcloud/stable20/lib/private/Console/Application.php on line 224 and exactly 2 expected in /srv/http/nextcloud/master/apps-repos/ldap_contacts_backend/lib/Command/Add.php:46
Stack trace:
#0 /srv/http/nextcloud/stable20/lib/private/Console/Application.php(224): OCA\LDAPContactsBackend\Command\Add->__construct()
#1 /srv/http/nextcloud/stable20/lib/private/Console/Application.php(136): OC\Console\Application->loadCommandsFromInfoXml(Array)
#2 /srv/http/nextcloud/stable20/console.php(99): OC\Console\Application->loadCommands(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 /srv/http/nextcloud/stable20/occ(11): require_once('/srv/http/nextc...')
```