### PR TITLE
connectionImporter may be null

### DIFF
--- a/lib/Command/Add.php
+++ b/lib/Command/Add.php
@@ -319,7 +319,7 @@ class Add extends Base {
 	}
 
 	protected function askImport(InputInterface $input, OutputInterface $output): void {
-		$availableConnections = $this->connectionImporter->getAvailableConnections();
+		$availableConnections = $this->connectionImporter ? $this->connectionImporter->getAvailableConnections() : [];
 		if(count($availableConnections) === 0) {
 			return;
 		}


### PR DESCRIPTION
could be done more elegantly with more overhead, but that's ok or now.

Fixes an `Error: Call to a member function getAvailableConnections() on null in /srv/http/nextcloud/stable22/apps-repos/ldap_contacts_backend/lib/Command/Add.php:322` error when no LDAP backend is configured.