### PR TITLE
[stable28] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -477,12 +477,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "762d54befc31afb0e007f2549e12040420b2312a"
+                "reference": "c0434f22a71dfb28d0862b7bc347ef963673c90c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/762d54befc31afb0e007f2549e12040420b2312a",
-                "reference": "762d54befc31afb0e007f2549e12040420b2312a",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/c0434f22a71dfb28d0862b7bc347ef963673c90c",
+                "reference": "c0434f22a71dfb28d0862b7bc347ef963673c90c",
                 "shasum": ""
             },
             "require": {
@@ -513,7 +513,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable28"
             },
-            "time": "2024-01-03T00:33:17+00:00"
+            "time": "2024-01-11T00:34:29+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency