### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -361,12 +361,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "50fef0ff2189206a5228b81044f1730c2aa4b396"
+                "reference": "89571e22da5e06b533e3fb68abe0a015e901eadd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/50fef0ff2189206a5228b81044f1730c2aa4b396",
-                "reference": "50fef0ff2189206a5228b81044f1730c2aa4b396",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/89571e22da5e06b533e3fb68abe0a015e901eadd",
+                "reference": "89571e22da5e06b533e3fb68abe0a015e901eadd",
                 "shasum": ""
             },
             "require": {
@@ -402,7 +402,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2026-03-31T01:18:57+00:00"
+            "time": "2026-04-11T01:15:54+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency