### PR TITLE
[stable32] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
-794da3d3e247bf6eb3601f542210906f appstore-build-publish.yml
+f776ffe8120cb9a8b2579bc30a7f7ca7 appstore-build-publish.yml
 2581a67c5bcdcd570427e6d51db767d7 fixup.yml
 80a58e5584612def0e751fcfb7669814 lint-info-xml.yml
 ccd8a55c60e35b84becb0f7005ce1286 lint-php-cs.yml
 5dcc3187a9460cb62a455235cbdb3562 lint-php.yml
-1c6d23a5f35e6bc1eea95c650e4f964b phpunit-mysql.yml
-fd94bce519297d48245483d469da9fcc phpunit-sqlite.yml
+5846b994639ccab0059bf23e141d389a phpunit-mysql.yml
+182cc739d33a2441d3a9278a9bff55b4 phpunit-sqlite.yml
 3c4a096b3b7dbaef0f8e5190ffe13518 pr-feedback.yml
 2070d9569f327e758b9ce2b924c28fef psalm.yml
 7db5b820f3750eebe988005a0bb2febd reuse.yml
 800d5b188aa885626cf4169fa2dfea9e update-nextcloud-ocp-approve-merge.yml
-8e930a499e9e608b95ef45193e90259e update-nextcloud-ocp.yml
+1a3e76e59e411598dbf3042cd687ec33 update-nextcloud-ocp.yml

--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Check composer.json
         id: check_composer
-        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: "${{ env.APP_NAME }}/composer.json"
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: Check Krankerl config
         id: krankerl
-        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: ${{ env.APP_NAME }}/krankerl.toml
 

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Check composer file existence
         id: check_composer
-        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: apps/${{ env.APP_NAME }}/composer.json
 

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Check composer file existence
         id: check_composer
-        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: apps/${{ env.APP_NAME }}/composer.json
 

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -62,10 +62,30 @@ jobs:
         if: steps.checkout.outcome == 'success'
         run: composer install
 
-      - name: Composer update nextcloud/ocp # zizmor: ignore[template-injection]
+      - name: Check composer bin for nextcloud/ocp exists
+        id: check_composer_bin
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
+        with:
+          files: vendor-bin/nextcloud-ocp/composer.json
+
+      - name: Composer update nextcloud/ocp
         id: update_branch
-        if: ${{ steps.checkout.outcome == 'success' && matrix.branches != 'main' }}
-        run: composer require --dev 'nextcloud/ocp:dev-${{ matrix.branches }}'
+        env:
+          USE_COMPOSER_BIN: ${{ steps.check_composer_bin.outputs.files_exists }}
+          BRANCH_NAME: ${{ matrix.branches }}
+        run: |
+          COMPOSER_CMD='composer'
+          if [[ "$USE_COMPOSER_BIN" == 'true' ]]; then
+            COMPOSER_CMD='composer bin nextcloud-ocp'
+          fi
+
+          PACKAGE_VERSION="nextcloud/ocp:dev-$BRANCH_NAME"
+          if [[ "$BRANCH_NAME" == 'main' ]]; then
+            PACKAGE_VERSION='nextcloud/ocp:dev-master'
+          fi
+
+          echo $COMPOSER_CMD require --dev $PACKAGE_VERSION
+          $COMPOSER_CMD require --dev $PACKAGE_VERSION
 
       - name: Raise on issue on failure
         uses: dacbd/create-issue-action@cdb57ab6ff8862aa09fee2be6ba77a59581921c2 # v2.0.0
@@ -74,40 +94,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: 'Failed to update nextcloud/ocp package on branch ${{ matrix.branches }}'
           body: 'Please check the output of the GitHub action and manually resolve the issues<br>${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}<br>${{ steps.codeowners.outputs.codeowners }}'
-
-      - name: Composer update nextcloud/ocp
-        id: update_main
-        if: ${{ steps.checkout.outcome == 'success' && matrix.branches == 'main' }}
-        run: composer require --dev nextcloud/ocp:dev-master
-
-      - name: Raise on issue on failure
-        uses: dacbd/create-issue-action@cdb57ab6ff8862aa09fee2be6ba77a59581921c2 # v2.0.0
-        if: ${{ steps.checkout.outcome == 'success' && failure() && steps.update_main.conclusion == 'failure' }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: 'Failed to update nextcloud/ocp package on branch ${{ matrix.branches }}'
-          body: 'Please check the output of the GitHub action and manually resolve the issues<br>${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}<br>${{ steps.codeowners.outputs.codeowners }}'
-
-      - name: Reset checkout 3rdparty
-        if: steps.checkout.outcome == 'success'
-        run: |
-          git clean -f 3rdparty
-          git checkout 3rdparty
-        continue-on-error: true
-
-      - name: Reset checkout vendor
-        if: steps.checkout.outcome == 'success'
-        run: |
-          git clean -f vendor
-          git checkout vendor
-        continue-on-error: true
-
-      - name: Reset checkout vendor-bin
-        if: steps.checkout.outcome == 'success'
-        run: |
-          git clean -f vendor-bin
-          git checkout vendor-bin
-        continue-on-error: true
 
       - name: Create Pull Request
         if: steps.checkout.outcome == 'success'
@@ -120,6 +106,11 @@ jobs:
           signoff: true
           branch: 'automated/noid/${{ matrix.branches }}-update-nextcloud-ocp'
           title: '[${{ matrix.branches }}] Update nextcloud/ocp dependency'
+          add-path: |
+            composer.json
+            composer.lock
+            vendor-bin/nextcloud-ocp/composer.json
+            vendor-bin/nextcloud-ocp/composer.lock
           body: |
             Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency
           labels: |


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [appstore-build-publish.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/appstore-build-publish.yml)
- 🆙 Updated [phpunit-mysql.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-mysql.yml)
  - Patch applied
- 🆙 Updated [phpunit-sqlite.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-sqlite.yml)
  - Patch applied
- 🆙 Updated [update-nextcloud-ocp.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/update-nextcloud-ocp.yml)
  - Patch applied